### PR TITLE
Algolia Indexing - approved objects only

### DIFF
--- a/packages/events/algolia.cfc
+++ b/packages/events/algolia.cfc
@@ -2,7 +2,6 @@
 
 	<!--- The basic rule is: if publicly visible content is changed, archive first --->
 
-
 	<cffunction name="saved" access="public" output="false" hint="Invoked immediately before DB is updated">
 		<cfargument name="typename" type="string" required="true" hint="The type of the object" />
 		<cfargument name="oType" type="any" required="true" hint="A CFC instance of the object type" />
@@ -26,9 +25,14 @@
 		</cfif>
 
 		<!--- update index --->
-		<cfif application.fc.lib.algolia.isIndexable(stProps)>
+		<cfif application.fc.lib.algolia.isIndexable(stProps)>		
 			<cfset structappend(stProps, application.fapi.getContentObject(typename=stProps.typename, objectid=stProps.objectid), false) />
-			<cfset application.fc.lib.algolia.importIntoIndex(stObject=stProps, operation="updated") />
+			<cfif StructKeyExists(stProps, 'status') AND stProps['status'] == 'approved'>
+				<cfif request.mode.debug><cflog file="algolia-event" text="saved(#arguments.typename#): update index stProperties=#serializeJSON(arguments.stProperties)#"></cfif>
+				<cfset application.fc.lib.algolia.importIntoIndex(stObject=stProps, operation="updated") />
+			<cfelse>
+				<cfif request.mode.debug><cflog file="algolia-event-draft" text="saved(#arguments.typename#): stProperties=#serializeJSON(arguments.stProperties)#"></cfif>
+			</cfif>
 		</cfif>
 	</cffunction>
 
@@ -40,8 +44,28 @@
 		<cfargument name="auditNote" type="string" required="true" />
 
 		<cfif application.fc.lib.algolia.isIndexable(arguments.stObject)>
+			
+			<cfif request.mode.debug><cflog file="algolia-event" text="deleted(#arguments.typename#): stObject=#serializeJSON(arguments.stObject)#"></cfif>
 			<cfset application.fc.lib.algolia.importIntoIndex(stObject=arguments.stObject, operation="deleted") />
 		</cfif>
+	</cffunction>
+
+	<cffunction name="statusChanged" access="public" hint="I am invoked when a content object has been deleted">
+		<cfargument name="typename" type="string" required="true" hint="The type of the object" />
+		<cfargument name="oType" type="any" required="true" hint="A CFC instance of the object type" />
+		<cfargument name="stObject" type="struct" required="true" hint="The object" />
+		<cfargument name="newStatus" type="string" required="true" />
+		<cfargument name="previousStatus" type="string" required="true" />
+		<cfargument name="auditNote" type="string" required="true" />
+
+ 		<cfif application.fc.lib.algolia.isIndexable(arguments.stObject)>
+			<!--- if was approved, remove from index --->
+			<cfif arguments.previousStatus == 'approved' AND arguments.newStatus != 'approved'>
+				<cfif request.mode.debug><cflog file="algolia-event" text="statusChanged(#arguments.typename#) Removing from index [newStatus=#arguments.newStatus#|previousStatus=#arguments.previousStatus#]: stObject=#serializeJSON(arguments.stObject)#"></cfif>
+				<cfset application.fc.lib.algolia.importIntoIndex(stObject=arguments.stObject, operation="deleted") />
+			</cfif>
+
+		</cfif> 
 	</cffunction>
 
 </cfcomponent>

--- a/packages/lib/algolia.cfc
+++ b/packages/lib/algolia.cfc
@@ -580,6 +580,12 @@ component {
 		if (not this.typeSetup[arguments.stObject.typename]) {
 			return false;
 		}
+		
+		/*
+		if (StructKeyExists(arguments.stObject, 'status') && arguments.stObject.status != 'approved') {
+			return false;
+		}
+		*/
 
 		var indexableTypes = getIndexableTypes();
 		return structKeyExists(indexableTypes, arguments.stObject.typename);
@@ -744,11 +750,7 @@ component {
 					
 				// Approved only - draft records do not get updated to approved; new records added to index each time object goes to draft
 				if (StructKeyExists(arguments.stObject, 'status') AND arguments.stObject['status'] != 'approved') {
-					stResult["typename"] = arguments.stObject.typename;
-					stResult["count"] = 0;
-					stResult["builtToDate"] = builtToDate;	
-
-					return 	stResult;
+					break;
 				}
 					
 					stContent = oContent.getData(objectid=qContent.objectid);

--- a/packages/lib/algolia.cfc
+++ b/packages/lib/algolia.cfc
@@ -663,6 +663,16 @@ component {
 					(not structKeyExists(oContent, "isIndexable") and isIndexable(indexName=indexname, stObject=stObject))
 				)
 			) {
+				
+				// Approved only - draft records do not get updated to approved; new records added to index each time object goes to draft
+				if (StructKeyExists(arguments.stObject, 'status') AND arguments.stObject['status'] != 'approved') {
+					stResult["typename"] = arguments.stObject.typename;
+					stResult["count"] = 0;
+					stResult["builtToDate"] = builtToDate;	
+	
+					return 	stResult;
+				}
+				
 				strOut.append('{ "action": "addObject", "indexName": "#indexName#", "body": ');
 				processObject(indexName, strOut, arguments.stObject);
 				strOut.append(' }, ');
@@ -731,6 +741,16 @@ component {
 		for (row in qContent) {
 			for (indexName in indexableTypes[qContent.typename]) {
 				if (qContent.operation eq "updated") {
+					
+				// Approved only - draft records do not get updated to approved; new records added to index each time object goes to draft
+				if (StructKeyExists(arguments.stObject, 'status') AND arguments.stObject['status'] != 'approved') {
+					stResult["typename"] = arguments.stObject.typename;
+					stResult["count"] = 0;
+					stResult["builtToDate"] = builtToDate;	
+
+					return 	stResult;
+				}
+					
 					stContent = oContent.getData(objectid=qContent.objectid);
 
 					if (

--- a/packages/lib/algolia.cfc
+++ b/packages/lib/algolia.cfc
@@ -770,7 +770,7 @@ component {
 					strOut.append(qContent.objectid);
 					strOut.append('" } }, ');
 				}
-			}
+			} //indexName
 
 			if (
 				strOut.length() * ((qContent.currentrow+1) / qContent.currentrow) gt arguments.requestSize or
@@ -780,10 +780,11 @@ component {
 				count = qContent.currentrow;
 				break;
 			}
-		}
+		} // row
+		
 		processingTime += getTickCount() - start;
 
-		strOut.delete(strOut.length()-2, strOut.length());
+		if (right(strOut, 2) == ', ') strOut.delete(strOut.length()-2, strOut.length());
 		strOut.append(' ] }');
 
 		if (count) {

--- a/packages/lib/algolia.cfc
+++ b/packages/lib/algolia.cfc
@@ -580,12 +580,6 @@ component {
 		if (not this.typeSetup[arguments.stObject.typename]) {
 			return false;
 		}
-		
-		/*
-		if (StructKeyExists(arguments.stObject, 'status') && arguments.stObject.status != 'approved') {
-			return false;
-		}
-		*/
 
 		var indexableTypes = getIndexableTypes();
 		return structKeyExists(indexableTypes, arguments.stObject.typename);

--- a/packages/lib/algolia.cfc
+++ b/packages/lib/algolia.cfc
@@ -748,12 +748,12 @@ component {
 			for (indexName in indexableTypes[qContent.typename]) {
 				if (qContent.operation eq "updated") {
 					
-				// Approved only - draft records do not get updated to approved; new records added to index each time object goes to draft
-				if (StructKeyExists(arguments.stObject, 'status') AND arguments.stObject['status'] != 'approved') {
-					break;
-				}
-					
 					stContent = oContent.getData(objectid=qContent.objectid);
+					
+					// Approved only - draft records do not get updated to approved; new records added to index each time object goes to draft
+					if (StructKeyExists(stContent, 'status') AND stContent['status'] != 'approved') {
+						break;
+					}
 
 					if (
 						(structKeyExists(oContent, "isIndexable") and oContent.isIndexable(indexName=indexname, stObject=stContent)) or


### PR DESCRIPTION
only send approved objects to Algolia index
if changed object no longer approved, remove from Algolia index